### PR TITLE
Add wiringPi lib to build config

### DIFF
--- a/examples/lighting-app/linux/BUILD.gn
+++ b/examples/lighting-app/linux/BUILD.gn
@@ -95,6 +95,8 @@ executable("chip-lighting-app") {
     cflags = [ "-Wconversion" ]
   }
 
+  libs = [ "wiringPi" ]
+
   output_dir = root_out_dir
 }
 

--- a/examples/lighting-app/linux/src/LightingManager.cpp
+++ b/examples/lighting-app/linux/src/LightingManager.cpp
@@ -22,7 +22,7 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <wiringPi.h>
 
-const int wiringPiPin = 1
+const int wiringPiPin = 1;
 
 LightingManager LightingManager::sLight;
 

--- a/lighting-gpio-app.md
+++ b/lighting-gpio-app.md
@@ -62,7 +62,9 @@ cd ~/wiringpi
 sudo ./build
 ```
 
-Run gn:
+The `BUILD.gn` file has been modified to have `wiringPi` lib linker.
+
+Build:
 
 ```
 source ~/connectedhomeip/scripts/activate.sh
@@ -70,22 +72,6 @@ source ~/connectedhomeip/scripts/activate.sh
 
 cd ~/connectedhomeip/examples/lighting-app/linux/
 gn gen out/build
-```
-
-Append `-lwiringPi` linker flag to `libs` in chip-lighting-app.ninja file for the compiler to use wiringPi library:
-
-```
-sudo nano ~/connectedhomeip/examples/lighting-app/linux/out/build/obj/chip-lighting-app.ninja
-```
-
-so it will look like:
-
-libs = -ldl -lpthread -lrt -lssl -lcrypto -lgio-2.0 -lgobject-2.0 -lglib-2.0
-**-lwiringPi**
-
-Then, run ninja:
-
-```
 ninja -C out/build
 ```
 


### PR DESCRIPTION
Add wiringPi to libs.

This results in the following entry in the ninja file:
```
  libs = -lwiringPi -ldl -lpthread -lrt -lssl -lcrypto -lgio-2.0 -lgobject-2.0 -lglib-2.0
```

